### PR TITLE
CI build by github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+
+ # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -1,0 +1,118 @@
+name: CI_build
+
+on: [push, pull_request]
+
+jobs:
+
+  build_windows:
+
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        build_configuration: [Release]
+        build_platform: ["Ninja"]
+
+    steps:
+
+    - name: Install openssl dev
+      run: |
+           choco install openssl --version=3.3.2
+           choco install ninja
+
+    - name: Add nmake
+      uses: ilammy/msvc-dev-cmd@v1
+
+    - name: Checkout repo
+      uses: actions/checkout@v4
+
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v4
+      with:
+        version: '6.7.*'
+        modules: 'qtscxml qtwebsockets qtshadertools qtconnectivity qtimageformats'
+        setup-python: 'false'
+
+    - name: generate cmake
+      run: |
+           cmake -G "${{ matrix.build_platform }}" -DCMAKE_BUILD_TYPE="${{ matrix.build_configuration }}" -B _build
+
+    - name: build cmake
+      run: |
+           cmake --build _build --config ${{ matrix.build_configuration }} --target package
+           cmake --install _build
+
+    - name: run ctest
+      run: |
+           ctest --test-dir _build --output-on-failure -C "${{ matrix.build_configuration }}"
+
+  build_linux:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        build_configuration: [Release]
+        build_platform: ["Unix Makefiles"]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install packages via apt
+      run: |
+           sudo apt update -qq && sudo apt install -y cmake pkg-config libssl-dev libudev-dev libhttp-parser-dev libpcsclite-dev libgl1-mesa-dev qt6-l10n-tools
+
+    # ubuntu 22.04 comes just with QT 6.2.4 and Qt >= 6.4 is required
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v4
+      with:
+        version: '6.7.2'
+        modules: 'qtscxml qtwebsockets qtshadertools qtconnectivity'
+        setup-python: 'false'
+
+    - name: generate cmake
+      run: |
+           cmake -G "${{ matrix.build_platform }}" -DCMAKE_BUILD_TYPE="${{ matrix.build_configuration }}" -B _build
+
+    - name: build cmake
+      run: |
+           cmake --build _build --config ${{ matrix.build_configuration }} --target package
+           sudo cmake --install _build
+
+    - name: run ctest
+      run: |
+           ctest --test-dir _build --output-on-failure -C "${{ matrix.build_configuration }}"
+
+  build_macos:
+
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        build_configuration: [Release]
+        build_platform: ["Unix Makefiles"]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v4
+      with:
+        version: '6.7.2'
+        modules: 'qtscxml qtwebsockets qtshadertools qtconnectivity qtimageformats'
+
+    - name: generate cmake
+      run: |
+           export OPENSSL_ROOT=/usr/local/opt/openssl/bin
+           export LDFLAGS=-L/usr/local/opt/openssl/lib
+           export CPPFLAGS=-I/usr/local/opt/openssl/include
+           export PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig/
+           cmake -G "${{ matrix.build_platform }}" -DCMAKE_BUILD_TYPE="${{ matrix.build_configuration }}" -B _build
+
+    - name: build cmake
+      run: |
+           cmake --build _build --config ${{ matrix.build_configuration }}
+
+    - name: run ctest
+      run: |
+           ctest --test-dir _build --output-on-failure -C "${{ matrix.build_configuration }}"

--- a/.github/workflows/CI_build_combined.yml
+++ b/.github/workflows/CI_build_combined.yml
@@ -1,0 +1,171 @@
+name: CI_build_combined
+
+on: [push, pull_request]
+
+env:
+  BUILD_DIR_LIBS_WIN: "c:/_build_libs"
+  BUILD_DIR_APP_WIN: "c:/_build"
+  BUILD_DIR_LIBS: "_build_libs"
+  BUILD_DIR_APP: "_build"
+
+
+jobs:
+  build_windows:
+
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        build_configuration: [Release]
+        build_platform: ["Ninja"]
+
+    steps:
+
+    - name: Install nmake replacement jom, ninja
+      run: |
+           choco install jom ninja
+
+    - name: Checkout repo
+      uses: actions/checkout@v4
+
+    - name: Add nmake
+      uses: ilammy/msvc-dev-cmd@v1
+
+    - name: generate cmake libs
+      run: |
+           cmake -G "${{ matrix.build_platform }}" -DCMAKE_BUILD_TYPE="${{ matrix.build_configuration }}" -B "${{ env.BUILD_DIR_LIBS_WIN }}"  D:\a\AusweisApp\AusweisApp\libs
+
+    - name: build cmake libs
+      run: |
+           cmake --build "${{ env.BUILD_DIR_LIBS_WIN }}" --config ${{ matrix.build_configuration }}
+
+    - name: generate cmake
+      run: |
+           cmake -G "${{ matrix.build_platform }}" -DCMAKE_BUILD_TYPE="${{ matrix.build_configuration }}" -B "${{ env.BUILD_DIR_APP_WIN }}"  -DCMAKE_PREFIX_PATH=c:\_build_libs\dist D:\a\AusweisApp\AusweisApp
+
+    - name: build cmake
+      run: |
+           cmake --build "${{ env.BUILD_DIR_APP_WIN }}" --config ${{ matrix.build_configuration }} --target package
+           cmake --install "${{ env.BUILD_DIR_APP_WIN }}"
+
+    - name: run ctest
+      run: |
+           ctest --test-dir "${{ env.BUILD_DIR_APP_WIN }}" --output-on-failure -C "${{ matrix.build_configuration }}"
+
+
+
+  build_linux:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        build_configuration: [Release]
+        build_platform: ["Ninja"]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install packages via apt
+      run: |
+           sudo apt-get update -qq && sudo apt install -y cmake pkg-config libssl-dev libudev-dev libhttp-parser-dev libpcsclite-dev libgl1-mesa-dev libdbus-1-dev libclang-15-dev libclang-14-dev libclang-13-dev ninja-build
+
+    - name: generate cmake libs
+      run: |
+           cmake -G "${{ matrix.build_platform }}" -DCMAKE_BUILD_TYPE="${{ matrix.build_configuration }}" -B ${{ env.BUILD_DIR_LIBS }}  ./libs
+
+    - name: build cmake libs
+      run: |
+           cmake --build ${{ env.BUILD_DIR_LIBS }} --config ${{ matrix.build_configuration }}
+
+    - name: generate cmake
+      run: |
+           cmake -G "${{ matrix.build_platform }}" -DCMAKE_BUILD_TYPE="${{ matrix.build_configuration }}" -B ${{ env.BUILD_DIR_APP }} -DCMAKE_PREFIX_PATH=./_build_libs/dist
+
+    - name: build cmake
+      run: |
+           cmake --build ${{ env.BUILD_DIR_APP }} --config ${{ matrix.build_configuration }}
+           sudo cmake --install ${{ env.BUILD_DIR_APP }}
+
+    - name: run ctest
+      run: |
+           ctest --test-dir ${{ env.BUILD_DIR_APP }} --output-on-failure -C "${{ matrix.build_configuration }}"
+
+
+  build_linux_android:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        build_configuration: [Release]
+        build_platform: ["Unix Makefiles"]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install packages via apt
+      run: |
+           sudo apt-get update -qq && sudo apt install -y cmake pkg-config libssl-dev libudev-dev libhttp-parser-dev libpcsclite-dev libgl1-mesa-dev libdbus-1-dev libclang-15-dev libclang-14-dev libclang-13-dev ninja-build
+           sudo apt -y remove firefox microsoft-edge-stable google-chrome-stable kotlin libmono* mono-runtime
+
+    - name: generate cmake libs
+      run: |
+           cmake -G "${{ matrix.build_platform }}" -DCMAKE_BUILD_TYPE="${{ matrix.build_configuration }}" -DCMAKE_TOOLCHAIN_FILE=../cmake/android.toolchain.cmake -B ${{ env.BUILD_DIR_LIBS }}  ./libs
+
+    - name: build cmake libs
+      run: |
+           cmake --build ${{ env.BUILD_DIR_LIBS }} --config ${{ matrix.build_configuration }}
+           cmake --install ${{ env.BUILD_DIR_LIBS }}
+
+  build_macos:
+
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        build_configuration: [Release]
+        build_platform: ["Ninja"]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: install ninja
+      run: |
+           brew install ninja
+
+    - name: generate cmake libs
+      run: |
+           cmake -G "${{ matrix.build_platform }}" -DCMAKE_BUILD_TYPE="${{ matrix.build_configuration }}" -B ${{ env.BUILD_DIR_LIBS }}  ./libs
+
+    - name: build cmake libs
+      run: |
+           cmake --build ${{ env.BUILD_DIR_LIBS }} --config ${{ matrix.build_configuration }}
+
+    - name: generate cmake
+      run: |
+           cmake -G "${{ matrix.build_platform }}" -DCMAKE_BUILD_TYPE="${{ matrix.build_configuration }}" -DCMAKE_PREFIX_PATH=./_build_libs/dist -B ${{ env.BUILD_DIR_APP }}
+
+  build_ios:
+
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        build_configuration: [Release]
+        build_platform: ["Unix Makefiles"]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: install ninja
+      run: |
+           brew install ninja
+
+    - name: generate cmake libs
+      run: |
+           cmake -G "${{ matrix.build_platform }}" -DCMAKE_BUILD_TYPE="${{ matrix.build_configuration }}" -DCMAKE_TOOLCHAIN_FILE=../cmake/iOS.toolchain.cmake -B ${{ env.BUILD_DIR_LIBS }}  ./libs
+
+    - name: build cmake libs
+      run: |
+           cmake --build ${{ env.BUILD_DIR_LIBS }} --config ${{ matrix.build_configuration }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
@@ -35,10 +35,18 @@ jobs:
       - name: Install dependencies
         run: sudo apt update -qq && sudo apt install -y cmake pkg-config libssl-dev libudev-dev libhttp-parser-dev libpcsclite-dev libqt6svg6-dev libqt6websockets6-dev qt6-base-dev qt6-base-private-dev qt6-declarative-dev qt6-connectivity-dev qt6-scxml-dev qt6-tools-dev qt6-tools-dev-tools libqt6opengl6-dev libqt6shadertools6-dev libgl1-mesa-dev qt6-l10n-tools
 
+      #QT > 6.4 is required but ubuntu 22.04 just has 6.2.4, so additional installation is needed
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: '6.7.2'
+          modules: 'qtscxml qtwebsockets qtshadertools qtconnectivity'
+          setup-python: 'false'
+
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,14 +5,14 @@ environment:
     - PlatformToolset: mingw-w64
       platform: mingw-w64
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-      QTPath: C:\Qt\6.3.1\mingw_64
-      OPENSSLPath: C:\OpenSSL-v30-Win64\bin
+      QTPath: C:\Qt\6.7\mingw_64
+      OPENSSLPath: C:\OpenSSL-v33-Win64\bin
 
     - PlatformToolset: v142
       platform: x64
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-      QTPath: C:\Qt\6.3.1\msvc2019_64
-      OPENSSLPath: C:\OpenSSL-v30-Win64\bin
+      QTPath: C:\Qt\6.7\msvc2019_64
+      OPENSSLPath: C:\OpenSSL-v33-Win64\bin
       ARCHI: amd64
 
 configuration:


### PR DESCRIPTION
Please comment what is of interest from your point of view, so I could modify the PR to the relevant once (comment out or remove).
Just used release builds. For debug builds also the ctests are running but for no target they are completely working and therefore not added here.

CI builds of desktop versions (against prebuild QT packages):
- windows msvc x64
- linux gcc x64 (QT apt package is just 6.2.4 on ubuntu 22.04, installed additionally 6.7.2
- macos clang (installation failure for QT 6.7.x)
CI builds of smartphone versions:
- linux android (NOK, cmake config issue, not added to workflow)
- macos ios (NOK, cmake config issue, not added to workflow)

CI builds of openssl, qt libs + ausweisapp with this libs:
- windows msvc x64
- linux gcc x64
- macos clang
CI builds of smartphone versions:
- linux android (just libs as there are config issues with the app)
- macos ios (just libs as there are config issues with the app)