### PR TITLE
Fix pairing UI on Linux

### DIFF
--- a/src/ui/qml/RemoteDeviceFilterModel.cpp
+++ b/src/ui/qml/RemoteDeviceFilterModel.cpp
@@ -9,6 +9,10 @@
 using namespace governikus;
 using namespace std::placeholders;
 
+INIT_FUNCTION([] {
+			qRegisterMetaType<RemoteDeviceFilterModel *>("RemoteDeviceFilterModel*");
+		})
+
 
 RemoteDeviceFilterModel::RemoteDeviceFilterModel(QAbstractItemModel* pSourceModel, const FilterFunctionType& pFilterFunction)
 	: QSortFilterProxyModel()


### PR DESCRIPTION
On Linux when building with Qt5, the pairing UI fails to display any devices, with the following warnings:

```
default       2023.09.07 17:11:32.358 10950 W (unknown:0)                                                                       : QMetaProperty::read: Unable to handle unregistered datatype 'RemoteDeviceFilterModel*' for property 'governikus::RemoteServiceModel::availableDevicesInPairingMode'
default       2023.09.07 17:11:32.358 10950 W (unknown:0)                                                                       : QMetaProperty::read: Unable to handle unregistered datatype 'RemoteDeviceFilterModel*' for property 'governikus::RemoteServiceModel::unavailablePairedDevices'
default       2023.09.07 17:11:32.359 10950 W (unknown:0)                                                                       : QMetaProperty::read: Unable to handle unregistered datatype 'RemoteDeviceFilterModel*' for property 'governikus::RemoteServiceModel::availablePairedDevices'

```

After registering this class with qRegisterMetaType, the pairing UI functions correctly on Linux, allowing me to pair a smartphone and authenticate to service providers using my Aufenthaltstitel.