### PR TITLE
Set the app's desktop file name

### DIFF
--- a/src/ui/qml/UIPlugInQml.cpp
+++ b/src/ui/qml/UIPlugInQml.cpp
@@ -192,6 +192,7 @@ UIPlugInQml::UIPlugInQml()
 #ifndef Q_OS_ANDROID
 	QGuiApplication::setWindowIcon(mTrayIcon.getIcon());
 #endif
+	QGuiApplication::setDesktopFileName(QStringLiteral("com.governikus.ausweisapp2"));
 
 	connect(&mTrayIcon, &TrayIcon::fireShow, this, &UIPlugInQml::show);
 	connect(&mTrayIcon, &TrayIcon::fireQuit, this, [this] {


### PR DESCRIPTION
Set the desktop file name for the application using [QGuiApplication::setDesktopFileName](https://doc.qt.io/qt-6/qguiapplication.html#desktopFileName-prop). This is used by window managers/Wayland compositors like KWin to display the proper window icon on Wayland rather than a generic Wayland icon.

On Linux, the desktop file is searched in $XDG_DATA_DIRS (see the [desktop file spec](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html), so the desktop file installed to `/usr/share/applications/com.governikus.ausweisapp2.desktop` is found this way.

Screenshot with v2.1.0 (i.e. without this change in place):

![screenshot_ausweisapp_wayland_icon](https://github.com/Governikus/AusweisApp/assets/6560939/21d72934-aee2-495a-975c-cdca53d36369)

Screenshot with this change in place:

![screenshot_ausweisapp_correct_icon](https://github.com/Governikus/AusweisApp/assets/6560939/2c3b5a4a-2057-47a2-ac45-84572d7f0dd3)
