### PR TITLE
Fix NFC presence timeout in Android 13+

### DIFF
--- a/docs/sdk/android.rst
+++ b/docs/sdk/android.rst
@@ -638,6 +638,7 @@ by way of example.
   import android.nfc.NfcAdapter;
   import android.nfc.tech.IsoDep;
   import java.util.Arrays;
+  import android.os.Bundle;
 
   import com.governikus.ausweisapp2.IAusweisApp2Sdk;
 
@@ -646,6 +647,7 @@ by way of example.
     private final Activity mActivity;
     private final NfcAdapter mAdapter;
     private final int mFlags;
+    private final Bundle mBundle;
     private final NfcAdapter.ReaderCallback mReaderCallback;
 
     ForegroundDispatcher(Activity pActivity, final IAusweisApp2Sdk pSdk, final String pSdkSessionID)
@@ -653,6 +655,8 @@ by way of example.
       mActivity = pActivity;
       mAdapter = NfcAdapter.getDefaultAdapter(mActivity);
       mFlags = NfcAdapter.FLAG_READER_NFC_A | NfcAdapter.FLAG_READER_NFC_B | NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK;
+      mBundle = new Bundle();
+      mBundle.putInt(NfcAdapter.EXTRA_READER_PRESENCE_CHECK_DELAY, 1000);
       mReaderCallback = new NfcAdapter.ReaderCallback()
       {
         public void onTagDiscovered(Tag pTag)
@@ -669,7 +673,7 @@ by way of example.
     {
       if (mAdapter != null)
       {
-        mAdapter.enableReaderMode(mActivity, mReaderCallback, mFlags, null);
+        mAdapter.enableReaderMode(mActivity, mReaderCallback, mFlags, mBundle);
       }
     }
 

--- a/src/android/MainActivity.java
+++ b/src/android/MainActivity.java
@@ -99,6 +99,7 @@ public class MainActivity extends QtActivity
 	private class NfcReaderMode
 	{
 		private final int mFlags;
+		private final Bundle mBundle;
 		private final NfcAdapter.ReaderCallback mCallback;
 		private boolean mEnabled;
 
@@ -108,6 +109,8 @@ public class MainActivity extends QtActivity
 					| NfcAdapter.FLAG_READER_NFC_B
 					| NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK
 					| NfcAdapter.FLAG_READER_NO_PLATFORM_SOUNDS;
+			mBundle = new Bundle();
+			mBundle.putInt(NfcAdapter.EXTRA_READER_PRESENCE_CHECK_DELAY, 1000);
 			mCallback = pTag ->
 			{
 				if (Arrays.asList(pTag.getTechList()).contains(IsoDep.class.getName()))
@@ -134,7 +137,7 @@ public class MainActivity extends QtActivity
 			if (adapter != null && !mEnabled)
 			{
 				mEnabled = true;
-				adapter.enableReaderMode(MainActivity.this, mCallback, mFlags, null);
+				adapter.enableReaderMode(MainActivity.this, mCallback, mFlags, mBundle);
 			}
 
 		}


### PR DESCRIPTION
This PR fixes a breaking bug which I encountered on my smartphone (Samsung Galaxy S10+, running Android 13, specifically LineageOS 20-20240402-microG-beyond2lte). The bug breaks the communication with the id card while the secure element in the card is still computing key transformations, because Android times out the NFC connection. This leads to a complete failure of functionality.

The core issue is that the Android API `NFCAdapter::enableReaderMode` [1] apparently had a subtle implementation change regarding the tag presence detection, sometime before or during Android 13 [2].

Specifically, the mechanism how the Android OS detects the presence of a tag has been modified. Because different NFC chipsets and Android versions handle function differently, there is no real standard how presence detection should work [2]. Especially on Broadcom chips, these seem to be issues with how the `enableReaderMode` handles presence checks [4].

The `EXTRA_READER_PRESENCE_CHECK_DELAY` configuration parameter [6] (which is passed via the Bundle configuration option in `enableReaderMode`) controls the timeout after which the Android OS considers a tag as lost. By default, this is 125 (presumably milliseconds) [5]. This explains why I was observing OS-induced reconnection attempts in my logfiles, as a GlobalPlatform key transformation might take longer than 125 milliseconds. Apparently Android uses the timeout value set via `IsoDep::setTimeout` only for active communication, not for the automatic OS-level presence checks.

The value of `1000` for `EXTRA_READER_PRESENCE_CHECK_DELAY` translates to presumably one second. I am unsure if it would be wise to set this any higher, I fear the Android tag detection system might hang if the timeout is too long. One second works fine for my phone - you might want to test this on your side as well.

This appears to be a general issue with the app and Android 13+ on select models, regardless of LineageOS or any other Android distribution.


[1] https://developer.android.com/reference/android/nfc/NfcAdapter#enableReaderMode(android.app.Activity,%20android.nfc.NfcAdapter.ReaderCallback,%20int,%20android.os.Bundle)

[2] https://community.st.com/t5/st25-nfc-rfid-tags-and-readers/what-is-the-difference-between-android-11-and-android-13-for-nfc/td-p/121846

[3] https://github.com/frankmorgner/vsmartcard/blob/master/remote-reader/app/src/main/java/com/vsmartcard/remotesmartcardreader/app/MainActivity.java#L163

[4] https://community.nxp.com/t5/NFC/Tranceive-method-throws-a-tag-lost-exception-only-for-specific/m-p/665270

[5] https://android.googlesource.com/platform/packages/apps/Nfc/+/master/src/com/android/nfc/NfcService.java#235

[6] https://developer.android.com/reference/android/nfc/NfcAdapter#EXTRA_READER_PRESENCE_CHECK_DELAY