### PR TITLE
Allow to overwrite default simulator file system data via json file

### DIFF
--- a/src/card/simulator/SimulatorFileSystem.h
+++ b/src/card/simulator/SimulatorFileSystem.h
@@ -28,6 +28,8 @@ class SimulatorFileSystem
 
 		void initMandatoryData();
 		void parseKey(const QJsonObject& pKey);
+		void populateDefaultData();
+		void populateJsonData(const QJsonObject& pData);
 
 	public:
 		SimulatorFileSystem();


### PR DESCRIPTION
This allows to overwrite the default simulator response with custom data. That allows for "fully automatic" authentication workflow when using the docker container, but with custom data, and without the need for a WebSocket client to provide the custom card data.

The file location is `~/.config/AusweisApp/sim-fs.json`