### PR TITLE
Fixing German typos for 'USB Kartenleser'

### DIFF
--- a/resources/translations/ausweisapp_de.ts
+++ b/resources/translations/ausweisapp_de.ts
@@ -4780,7 +4780,7 @@ LABEL ANDROID IOS</extracomment>
     <message>
         <source>USB card reader</source>
         <extracomment>LABEL DESKTOP</extracomment>
-        <translation>USB Kartenleser</translation>
+        <translation>USB-Kartenleser</translation>
     </message>
     <message>
         <source>Security and privacy</source>
@@ -5490,7 +5490,7 @@ Um fortzufahren, verwenden Sie Ihren Ausweis, indem Sie die NFC-Schnittstelle au
     </message>
     <message>
         <source>USB card reader</source>
-        <translation>USB Kartenleser</translation>
+        <translation>USB-Kartenleser</translation>
     </message>
     <message>
         <source>Found new USB card reader that is suitable for the ID card. The workflow may now be continued.</source>


### PR DESCRIPTION
Hi,

Fixed a minor German typo for a so called 'Durchkopplung', which is missing and always triggers me when using the app.

If something's missing for the pull process please let me know or just take this minor change into your teams.