### PR TITLE
Use secure WebSocket (wss://) and HTTPs for redirect URLs

### DIFF
--- a/src/ui/proxy/RedirectRequest.cpp
+++ b/src/ui/proxy/RedirectRequest.cpp
@@ -107,7 +107,7 @@ RedirectRequest::~RedirectRequest()
 
 void RedirectRequest::sendHttpRedirect()
 {
-	const auto& scheme = mRequest->isUpgrade() ? QByteArrayLiteral("ws://") : QByteArrayLiteral("http://");
+	const auto& scheme = mRequest->isUpgrade() ? QByteArrayLiteral("wss://") : QByteArrayLiteral("https://");
 	const auto host = mRequest->getHeader(QByteArrayLiteral("host")).replace(QByteArray::number(mRequest->getLocalPort()), QByteArray::number(peerPort()));
 	const auto url = scheme + host + mRequest->getUrl().toString().toLatin1();
 


### PR DESCRIPTION
Replaced `ws://` with `wss://` and `http://` with `https://` to ensure encrypted communication - improves security and avoids mixed-content issues.