### PR TITLE
Fix incorrect desktop file keywords format

### DIFF
--- a/resources/packaging/linux/com.governikus.ausweisapp2.desktop.in
+++ b/resources/packaging/linux/com.governikus.ausweisapp2.desktop.in
@@ -7,6 +7,6 @@ StartupNotify=true
 Terminal=false
 Categories=System;Security;
 GenericName=Authentication App
-Keywords=nPA,eID,eAT,Personalausweis,Aufenthaltstitel,Identity,Card
+Keywords=nPA;eID;eAT;Personalausweis;Aufenthaltstitel;Identity;Card
 Name=AusweisApp
 StartupWMClass=AusweisApp


### PR DESCRIPTION
Use semicolons instead of commas for keywords in desktop file for Linux integration to conform to https://specifications.freedesktop.org/desktop-entry-spec/1.1/value-types.html