### PR TITLE
Further GHA CI corrections

### DIFF
--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -25,14 +25,16 @@ jobs:
           dotnet tool install --global wix
 
       - name: Add nmake
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: TheMrMilchmann/setup-msvc-dev@v4
+        with:
+          arch: x64
 
       - name: checkout files with lineending LF to overcome issue with yamllint on windows
         run: |
           git config --global core.autocrlf false
 
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
@@ -41,9 +43,18 @@ jobs:
           modules: 'qtscxml qtwebsockets qtshadertools qtconnectivity qtimageformats'
           setup-python: 'false'
 
+      - name: vcpkg build
+        uses: johnwason/vcpkg-action@v8
+        id: vcpkg
+        with:
+          pkgs: llhttp
+          triplet: x64-windows-release
+          token: ${{ github.token }}
+
       - name: generate cmake
         run: |
-          cmake -G "${{ matrix.build_platform }}" -DCMAKE_BUILD_TYPE="${{ matrix.build_configuration }}" -B "${{ env.BUILD_DIR_APP }}"
+          cmake ${{ steps.vcpkg.outputs.vcpkg-cmake-config }} -G "${{ matrix.build_platform }}" `
+                -DCMAKE_BUILD_TYPE="${{ matrix.build_configuration }}" -B "${{ env.BUILD_DIR_APP }}"
 
       - name: build cmake
         run: |
@@ -52,11 +63,20 @@ jobs:
 
       - name: run ctest
         run: |
-          ctest --test-dir "${{ env.BUILD_DIR_APP }}" --output-on-failure -C "${{ matrix.build_configuration }}"
+          ctest --test-dir ${{ env.BUILD_DIR_APP }} --output-on-failure -C "${{ matrix.build_configuration }}" --output-junit junit.xml
+
+      - name: Report Test results
+        uses: dorny/test-reporter@v3
+        if: success() || failure()
+        with:
+          name: ctest Tests
+          path: ${{ env.BUILD_DIR_APP }}/junit.xml
+          reporter: java-junit
+
 
   build_linux:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     strategy:
       fail-fast: false
       matrix:
@@ -64,7 +84,7 @@ jobs:
         build_platform: ["Ninja"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install packages via apt
         run: |
@@ -89,7 +109,16 @@ jobs:
 
       - name: run ctest
         run: |
-          ctest --test-dir ${{ env.BUILD_DIR_APP }} --output-on-failure -C "${{ matrix.build_configuration }}"
+          ctest --test-dir ${{ env.BUILD_DIR_APP }} --output-on-failure -C "${{ matrix.build_configuration }}" --output-junit junit.xml
+
+      - name: Report Test results
+        uses: dorny/test-reporter@v3
+        if: success() || failure()
+        with:
+          name: ctest Tests
+          path: ${{ env.BUILD_DIR_APP }}/junit.xml
+          reporter: java-junit
+
 
   build_macos:
 
@@ -101,7 +130,11 @@ jobs:
         build_platform: ["Ninja"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
+
+      - name: install llhttp
+        run: |
+             brew install llhttp
 
       - name: install ninja
         run: |
@@ -127,4 +160,12 @@ jobs:
 
       - name: run ctest
         run: |
-          ctest --test-dir ${{ env.BUILD_DIR_APP }} --output-on-failure -C "${{ matrix.build_configuration }}"
+          ctest --test-dir ${{ env.BUILD_DIR_APP }} --output-on-failure -C "${{ matrix.build_configuration }}" --output-junit junit.xml
+
+      - name: Report Test results
+        uses: dorny/test-reporter@v3
+        if: success() || failure()
+        with:
+          name: ctest Tests
+          path: ${{ env.BUILD_DIR_APP }}/junit.xml
+          reporter: java-junit

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -25,7 +25,7 @@ jobs:
           dotnet tool install --global wix
 
       - name: Add nmake
-        uses: TheMrMilchmann/setup-msvc-dev@v4
+        uses: TheMrMilchmann/setup-msvc-dev@368ef7d1ee4d1171b31d4a7f67f4d954f903f5a9  # v4.1.0
         with:
           arch: x64
 
@@ -34,17 +34,17 @@ jobs:
           git config --global core.autocrlf false
 
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.01
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@v4
+        uses: jurplel/install-qt-action@48d3ad6db93f3627c8ee7a0454bc6f3744f7e730  # v4.3.1
         with:
           version: '6.10.*'
           modules: 'qtscxml qtwebsockets qtshadertools qtconnectivity qtimageformats'
           setup-python: 'false'
 
       - name: vcpkg build
-        uses: johnwason/vcpkg-action@v8
+        uses: johnwason/vcpkg-action@04c68c847bf5196ecaa72331ecf51208583916ef  # v8.0.0
         id: vcpkg
         with:
           pkgs: llhttp
@@ -66,7 +66,7 @@ jobs:
           ctest --test-dir ${{ env.BUILD_DIR_APP }} --output-on-failure -C "${{ matrix.build_configuration }}" --output-junit junit.xml
 
       - name: Report Test results
-        uses: dorny/test-reporter@v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2  # v3.0.0
         if: success() || failure()
         with:
           name: ctest Tests
@@ -84,7 +84,7 @@ jobs:
         build_platform: ["Ninja"]
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.01
 
       - name: Install packages via apt
         run: |
@@ -92,7 +92,7 @@ jobs:
                                                      libgl1-mesa-dev qt6-l10n-tools ninja-build
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@v4
+        uses: jurplel/install-qt-action@48d3ad6db93f3627c8ee7a0454bc6f3744f7e730  # v4.3.1
         with:
           version: '6.10.*'
           modules: 'qtscxml qtwebsockets qtshadertools qtconnectivity'
@@ -112,7 +112,7 @@ jobs:
           ctest --test-dir ${{ env.BUILD_DIR_APP }} --output-on-failure -C "${{ matrix.build_configuration }}" --output-junit junit.xml
 
       - name: Report Test results
-        uses: dorny/test-reporter@v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2  # v3.0.0
         if: success() || failure()
         with:
           name: ctest Tests
@@ -130,7 +130,7 @@ jobs:
         build_platform: ["Ninja"]
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.01
 
       - name: install llhttp
         run: |
@@ -141,7 +141,7 @@ jobs:
           brew install ninja
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@v4
+        uses: jurplel/install-qt-action@48d3ad6db93f3627c8ee7a0454bc6f3744f7e730  # v4.3.1
         with:
           version: '6.10.*'
           modules: 'qtscxml qtwebsockets qtshadertools qtconnectivity qtimageformats'
@@ -163,7 +163,7 @@ jobs:
           ctest --test-dir ${{ env.BUILD_DIR_APP }} --output-on-failure -C "${{ matrix.build_configuration }}" --output-junit junit.xml
 
       - name: Report Test results
-        uses: dorny/test-reporter@v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2  # v3.0.0
         if: success() || failure()
         with:
           name: ctest Tests

--- a/.github/workflows/CI_build_combined.yml
+++ b/.github/workflows/CI_build_combined.yml
@@ -31,13 +31,15 @@ jobs:
 
       - name: Set up GITHUB_PATH for patch on Windows
         # Needed to use GNU patch instead of Strawberry Perl patch (https://github.com/actions/runner-images/issues/5459)
-        run: echo "C:\Program Files\Git\usr\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+        run: Remove-Item -Path C:\Strawberry\c\bin\patch.exe -Force
 
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Add nmake
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: TheMrMilchmann/setup-msvc-dev@v4
+        with:
+          arch: x64
 
       - name: generate cmake libs
         run: |
@@ -51,7 +53,7 @@ jobs:
       - name: generate cmake
         run: |
           cmake -G "${{ matrix.build_platform }}" -DCMAKE_BUILD_TYPE="${{ matrix.build_configuration }}" -B "${{ env.BUILD_DIR_APP_WIN }}" `
-                -DCMAKE_PREFIX_PATH=c:\_build_libs\dist D:\a\AusweisApp\AusweisApp
+                -DCMAKE_PREFIX_PATH=${{ env.BUILD_DIR_LIBS_WIN }}\dist D:\a\AusweisApp\AusweisApp
 
       - name: build cmake
         run: |
@@ -60,11 +62,20 @@ jobs:
 
       - name: run ctest
         run: |
-          ctest --test-dir "${{ env.BUILD_DIR_APP_WIN }}" --output-on-failure -C "${{ matrix.build_configuration }}"
+          ctest --test-dir "${{ env.BUILD_DIR_APP_WIN }}" --output-on-failure -C "${{ matrix.build_configuration }}" --output-junit junit.xml
+
+      - name: Report Test results
+        uses: dorny/test-reporter@v3
+        if: success() || failure()
+        with:
+          name: ctest Tests
+          path: ${{ env.BUILD_DIR_APP_WIN }}/junit.xml
+          reporter: java-junit
+
 
   build_linux:
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -72,12 +83,13 @@ jobs:
         build_platform: ["Ninja"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install packages via apt
         run: |
-          sudo apt-get update -qq && sudo apt install -y cmake pkg-config libssl-dev libudev-dev llhttp-dev libpcsclite-dev \
+          sudo apt-get update -qq && sudo apt install -y cmake pkg-config libssl-dev libudev-dev libpcsclite-dev \
                                      libgl1-mesa-dev libdbus-1-dev libclang-16-dev libclang-17-dev libclang-18-dev ninja-build
+          sudo apt -y remove firefox microsoft-edge-stable google-chrome-stable kotlin libmono* mono-runtime ruby* rust* java*
 
       - name: generate cmake libs
         run: |
@@ -99,11 +111,20 @@ jobs:
 
       - name: run ctest
         run: |
-          ctest --test-dir ${{ env.BUILD_DIR_APP }} --output-on-failure -C "${{ matrix.build_configuration }}"
+          ctest --test-dir ${{ env.BUILD_DIR_APP }} --output-on-failure -C "${{ matrix.build_configuration }}" --output-junit junit.xml
+
+      - name: Report Test results
+        uses: dorny/test-reporter@v3
+        if: success() || failure()
+        with:
+          name: ctest Tests
+          path: ${{ env.BUILD_DIR_APP }}/junit.xml
+          reporter: java-junit
+
 
   build_linux_android:
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -111,11 +132,11 @@ jobs:
         build_platform: ["Ninja"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install packages via apt
         run: |
-          sudo apt-get update -qq && sudo apt install -y cmake pkg-config libssl-dev libudev-dev llhttp-dev libpcsclite-dev \
+          sudo apt-get update -qq && sudo apt install -y cmake pkg-config libssl-dev libudev-dev libpcsclite-dev \
                                      libgl1-mesa-dev libdbus-1-dev libclang-16-dev libclang-17-dev libclang-18-dev ninja-build
           sudo apt -y remove firefox microsoft-edge-stable google-chrome-stable kotlin libmono* mono-runtime
 
@@ -132,7 +153,7 @@ jobs:
       - name: generate cmake
         run: |
           cmake -G "${{ matrix.build_platform }}" -DCMAKE_BUILD_TYPE="${{ matrix.build_configuration }}" \
-                -DCMAKE_PREFIX_PATH=/home/runner/work/AusweisApp/_build_libs/dist \
+                -DCMAKE_PREFIX_PATH=${{ env.BUILD_DIR_LIBS }}/dist \
                 -DCMAKE_TOOLCHAIN_FILE=./cmake/android.toolchain.cmake -B ${{ env.BUILD_DIR_APP }}
 
       - name: build cmake
@@ -142,7 +163,16 @@ jobs:
 
       - name: run ctest
         run: |
-          ctest --test-dir ${{ env.BUILD_DIR_APP }} --output-on-failure -C "${{ matrix.build_configuration }}"
+          ctest --test-dir ${{ env.BUILD_DIR_APP }} --output-on-failure -C "${{ matrix.build_configuration }}" --output-junit junit.xml
+
+      - name: Report Test results
+        uses: dorny/test-reporter@v3
+        if: success() || failure()
+        with:
+          name: ctest Tests
+          path: ${{ env.BUILD_DIR_APP }}/junit.xml
+          reporter: java-junit
+
 
   build_macos:
 
@@ -154,7 +184,7 @@ jobs:
         build_platform: ["Ninja"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: install ninja
         run: |
@@ -162,7 +192,8 @@ jobs:
 
       - name: generate cmake libs
         run: |
-          cmake -G "${{ matrix.build_platform }}" -DCMAKE_BUILD_TYPE="${{ matrix.build_configuration }}" -B ${{ env.BUILD_DIR_LIBS }} ./libs
+          cmake -G "${{ matrix.build_platform }}" -DCMAKE_BUILD_TYPE="${{ matrix.build_configuration }}" \
+                -B ${{ env.BUILD_DIR_LIBS }}  ./libs
 
       - name: build cmake libs
         run: |
@@ -180,7 +211,16 @@ jobs:
 
       - name: run ctest
         run: |
-          ctest --test-dir ${{ env.BUILD_DIR_APP }} --output-on-failure -C "${{ matrix.build_configuration }}"
+          ctest --test-dir ${{ env.BUILD_DIR_APP }} --output-on-failure -C "${{ matrix.build_configuration }}" --output-junit junit.xml
+
+      - name: Report Test results
+        uses: dorny/test-reporter@v3
+        if: success() || failure()
+        with:
+          name: ctest Tests
+          path: ${{ env.BUILD_DIR_APP }}/junit.xml
+          reporter: java-junit
+
 
   build_ios:
 
@@ -192,7 +232,7 @@ jobs:
         build_platform: ["Ninja"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: install ninja
         run: |
@@ -210,7 +250,7 @@ jobs:
       - name: generate cmake
         run: |
           cmake -G "${{ matrix.build_platform }}" -DCMAKE_BUILD_TYPE="${{ matrix.build_configuration }}" \
-                -DCMAKE_PREFIX_PATH=/Users/runner/work/AusweisApp/_build_libs/dist \
+                -DCMAKE_PREFIX_PATH=${{ env.BUILD_DIR_LIBS }}/dist \
                 -DCMAKE_TOOLCHAIN_FILE=./cmake/iOS.toolchain.cmake -B ${{ env.BUILD_DIR_APP }}
 
       - name: build cmake
@@ -220,4 +260,12 @@ jobs:
 
       - name: run ctest
         run: |
-          ctest --test-dir ${{ env.BUILD_DIR_APP }} --output-on-failure -C "${{ matrix.build_configuration }}"
+          ctest --test-dir ${{ env.BUILD_DIR_APP }} --output-on-failure -C "${{ matrix.build_configuration }}" --output-junit junit.xml
+
+      - name: Report Test results
+        uses: dorny/test-reporter@v3
+        if: success() || failure()
+        with:
+          name: ctest Tests
+          path: ${{ env.BUILD_DIR_APP }}/junit.xml
+          reporter: java-junit

--- a/.github/workflows/CI_build_combined.yml
+++ b/.github/workflows/CI_build_combined.yml
@@ -34,10 +34,10 @@ jobs:
         run: Remove-Item -Path C:\Strawberry\c\bin\patch.exe -Force
 
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.01
 
       - name: Add nmake
-        uses: TheMrMilchmann/setup-msvc-dev@v4
+        uses: TheMrMilchmann/setup-msvc-dev@368ef7d1ee4d1171b31d4a7f67f4d954f903f5a9  # v4.1.0
         with:
           arch: x64
 
@@ -65,7 +65,7 @@ jobs:
           ctest --test-dir "${{ env.BUILD_DIR_APP_WIN }}" --output-on-failure -C "${{ matrix.build_configuration }}" --output-junit junit.xml
 
       - name: Report Test results
-        uses: dorny/test-reporter@v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2  # v3.0.0
         if: success() || failure()
         with:
           name: ctest Tests
@@ -83,7 +83,7 @@ jobs:
         build_platform: ["Ninja"]
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.01
 
       - name: Install packages via apt
         run: |
@@ -114,7 +114,7 @@ jobs:
           ctest --test-dir ${{ env.BUILD_DIR_APP }} --output-on-failure -C "${{ matrix.build_configuration }}" --output-junit junit.xml
 
       - name: Report Test results
-        uses: dorny/test-reporter@v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2  # v3.0.0
         if: success() || failure()
         with:
           name: ctest Tests
@@ -132,7 +132,7 @@ jobs:
         build_platform: ["Ninja"]
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.01
 
       - name: Install packages via apt
         run: |
@@ -166,7 +166,7 @@ jobs:
           ctest --test-dir ${{ env.BUILD_DIR_APP }} --output-on-failure -C "${{ matrix.build_configuration }}" --output-junit junit.xml
 
       - name: Report Test results
-        uses: dorny/test-reporter@v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2  # v3.0.0
         if: success() || failure()
         with:
           name: ctest Tests
@@ -184,7 +184,7 @@ jobs:
         build_platform: ["Ninja"]
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.01
 
       - name: install ninja
         run: |
@@ -214,7 +214,7 @@ jobs:
           ctest --test-dir ${{ env.BUILD_DIR_APP }} --output-on-failure -C "${{ matrix.build_configuration }}" --output-junit junit.xml
 
       - name: Report Test results
-        uses: dorny/test-reporter@v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2  # v3.0.0
         if: success() || failure()
         with:
           name: ctest Tests
@@ -232,7 +232,7 @@ jobs:
         build_platform: ["Ninja"]
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.01
 
       - name: install ninja
         run: |
@@ -263,7 +263,7 @@ jobs:
           ctest --test-dir ${{ env.BUILD_DIR_APP }} --output-on-failure -C "${{ matrix.build_configuration }}" --output-junit junit.xml
 
       - name: Report Test results
-        uses: dorny/test-reporter@v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2  # v3.0.0
         if: success() || failure()
         with:
           name: ctest Tests

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,7 +11,7 @@ name: "CodeQL"
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     permissions:
       actions: read
       contents: read
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
@@ -32,19 +32,15 @@ jobs:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
-      - name: Install dependencies
+      - name: Install packages via apt
         run: |
-          sudo apt update -qq && sudo apt install -y cmake pkg-config libssl-dev libudev-dev llhttp-dev libpcsclite-dev \
-                                                     libqt6svg6-dev libqt6websockets6-dev qt6-base-dev qt6-base-private-dev \
-                                                     qt6-declarative-dev qt6-connectivity-dev qt6-scxml-dev qt6-tools-dev \
-                                                     qt6-tools-dev-tools libqt6opengl6-dev libqt6shadertools6-dev \
-                                                     libgl1-mesa-dev qt6-l10n-tools
+          sudo apt update -qq && sudo apt install -y cmake pkg-config libssl-dev libudev-dev libllhttp-dev libpcsclite-dev \
+                                                     libgl1-mesa-dev qt6-l10n-tools ninja-build
 
-      # QT additional installation is needed as ubuntu typically has older version
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
-          version: '6.10.2'
+          version: '6.10.*'
           modules: 'qtscxml qtwebsockets qtshadertools qtconnectivity'
           setup-python: 'false'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.01
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd  # v4.37.7
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
@@ -38,14 +38,14 @@ jobs:
                                                      libgl1-mesa-dev qt6-l10n-tools ninja-build
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@v4
+        uses: jurplel/install-qt-action@48d3ad6db93f3627c8ee7a0454bc6f3744f7e730  # v4.3.1
         with:
           version: '6.10.*'
           modules: 'qtscxml qtwebsockets qtshadertools qtconnectivity'
           setup-python: 'false'
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd  # v4.37.7
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
- usage of vcpkg for windows llhttp build (remaining issue with yamllint), apt package for linux and brew for macos
- use env vars also for DCMAKE_PREFIX_PATH
- solve windows patch issue by removing C:/Strawberry/c/bin/patch.exe
- replace outdated ilammy/msvc-dev-cmd@v1 by TheMrMilchmann/setup-msvc-dev@v4
- free space on linux build by removing apt packages
- use action test-reporter@v3 to create reports of ctest results
- initial adapt build for codeql.yml

@misery  see
https://github.com/chcg/AusweisApp/actions/runs/28314350091
https://github.com/chcg/AusweisApp/actions/runs/28314350095